### PR TITLE
Center the initials vertically

### DIFF
--- a/routes/initials.js
+++ b/routes/initials.js
@@ -23,7 +23,7 @@ const generateSvg = (name, colors, backgroundColor, foregroundColor) => {
   const firstInitial = firstName.length > 0 ? firstName[0] : ''
   const lastInitial = lastName.length > 0 ? lastName[0] : ''
   const initials = `${firstInitial}${lastInitial}`.toUpperCase()
-  const letters = `<text font-family="Helvetica" font-size="14px" x="50%" y="50%" dy="0.3em" fill="#${textColor}" text-anchor="middle">${initials}</text>`
+  const letters = `<text font-family="Helvetica" font-size="14px" x="50%" y="50%" fill="#${textColor}" alignment-baseline="central" text-anchor="middle">${initials}</text>`
 
   return [
     '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"',


### PR DESCRIPTION
I noticed the initials weren't quite in the center of the image vertically (they were a few pixels too high).

This change uses the `alignment-baseline` attribute to make sure they're centered (see https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline).